### PR TITLE
Fix: Cálculo del mínimo personal según Art. 63 LIRPF

### DIFF
--- a/Calculo_Salario_IRPF.py
+++ b/Calculo_Salario_IRPF.py
@@ -218,7 +218,22 @@ def procesar_ano(anio):
         base_imponible = max(0, rendimiento_neto - red_trabajo)
 
         cuotas_tramos, cuota_integra = calcular_cuotas_por_tramo(base_imponible, p['tramos_irpf'])
-        cuota_minimo = p['irpf_minimo'] * p['tramos_irpf'][0][1]
+        # Fix: calcular cuota del mínimo personal recorriendo la escala (Art. 63 LIRPF)
+        # En vez de multiplicar por el primer tipo (falso para mínimos > primer tramo)
+        minimo = p['irpf_minimo']
+        cuota_minimo = 0.0
+        prev_lim = 0.0
+        remaining = minimo
+        for lim, tipo in p['tramos_irpf']:
+            if remaining <= 0:
+                break
+            if base_imponible > prev_lim:
+                ancho = lim - prev_lim
+                disponible = min(remaining, ancho, min(base_imponible, lim) - prev_lim)
+                if disponible > 0:
+                    cuota_minimo += disponible * tipo
+                    remaining -= disponible
+            prev_lim = lim
         cuota_teorica = max(0, cuota_integra - cuota_minimo)
 
         deduccion = p['deduccion_smi'](bruto)
@@ -287,7 +302,21 @@ def calcular_nomina_agregada(bruto, anio, p):
             q_integra += (base_imp - lim_ant) * tipo
             break
 
-    q_min = p['irpf_minimo'] * p['tramos_irpf'][0][1]
+    # Fix: calcular cuota del mínimo personal recorriendo la escala (Art. 63 LIRPF)
+    minimo = p['irpf_minimo']
+    q_min = 0.0
+    prev_lim = 0.0
+    remaining = minimo
+    for lim, tipo in p['tramos_irpf']:
+        if remaining <= 0:
+            break
+        if base_imp > prev_lim:
+            ancho = lim - prev_lim
+            disponible = min(remaining, ancho, min(base_imp, lim) - prev_lim)
+            if disponible > 0:
+                q_min += disponible * tipo
+                remaining -= disponible
+        prev_lim = lim
     q_teorica = max(0, q_integra - q_min)
     q_smi = max(0, q_teorica - p['deduccion_smi'](bruto))
 


### PR DESCRIPTION
## Bug

The calculation of `cuota_minimo` applies the mínimo personal (5,550€) as a flat multiplication by the first bracket rate (19%):

```python
cuota_minimo = p['irpf_minimo'] * p['tramos_irpf'][0][1]  # 5550 × 0.19 = 1054.50
```

This is **incorrect** per Art. 63 LIRPF. The minimum personal should reduce the cuota íntegra by calculating the tax on the minimum amount **through the full IRPF scale**, not just multiplying by the first rate.

## When it matters

At **14,000€ bruto**: base liquidable = 3,788€. The minimum (5,550€) exceeds the base, so the correct cuota_minimo should be **719.72€** (limited by the taxpayer's base), not 1,054.50€. The flat method overstates the deduction.

At **35,000€+ bruto**: both methods give the same result because 5,550€ fits entirely within the first bracket (12,450€ @ 19%).

## Fix

Replace the flat calculation with a proper scale traversal:

```python
minimo = p['irpf_minimo']
cuota_minimo = 0.0
prev_lim = 0.0
remaining = minimo
for lim, tipo in p['tramos_irpf']:
    if remaining <= 0:
        break
    if base_imponible > prev_lim:
        ancho = lim - prev_lim
        disponible = min(remaining, ancho, min(base_imponible, lim) - prev_lim)
        if disponible > 0:
            cuota_minimo += disponible * tipo
            remaining -= disponible
    prev_lim = lim
```

This ensures the minimum personal is correctly applied across all brackets, matching how AEAT calculates it (Art. 63 LIRPF: the minimum reduces the cuota, not the base).

## Files changed

- `Calculo_Salario_IRPF.py`: 2 locations (detailed engine + aggregate engine)

## Testing

- 35,000€ bruto: cuota_minimo = 1,054.50€ (unchanged, 5,550€ fits in first bracket)
- 14,000€ bruto: cuota_minimo = 719.72€ (was 1,054.50€, now correctly limited)