### PR TITLE
[codex] Add lightweight CLI for salary queries

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -95,3 +95,33 @@ La salida es equivalente a `python3 cli.py salario 30000 --anio 2026`.
 ## Nota
 
 El CLI reutiliza las funciones de `Calculo_Salario_IRPF.py`, pero evita ejecutar la sección final que genera `Auditoria_Integral_Nominas_e_Inflacion_2012_2026.xlsx`.
+
+## Validación
+
+Para comprobar que el CLI devuelve resultados coherentes con el Excel masivo, se generó localmente el archivo completo ejecutando:
+
+```bash
+python3 Calculo_Salario_IRPF.py
+```
+
+Resultado de la validación:
+
+```text
+Archivo generado: Auditoria_Integral_Nominas_e_Inflacion_2012_2026.xlsx
+Tamaño aproximado: 144.8 MB
+Hojas: 18
+DAT_2012, DAT_2024, DAT_2025, DAT_2026: 100002 filas cada una, incluyendo cabecera
+```
+
+También se compararon filas representativas del Excel contra el motor usado por el CLI:
+
+```text
+OK DAT_2026 bruto 30000: neto 23,124.00 €
+OK DAT_2026 bruto 50000: neto 35,545.50 €
+OK DAT_2025 bruto 30000: neto 23,128.20 €
+OK DAT_2024 bruto 30000: neto 23,130.30 €
+OK DAT_2012 bruto 30000: neto 22,666.59 €
+VALIDACION_OK
+```
+
+El Excel masivo no se incluye en el repositorio porque es un artefacto pesado y reproducible.

--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,97 @@
+# CLI de consulta rápida
+
+Este fichero documenta `cli.py`, una capa ligera para consultar cálculos de salario sin generar el Excel masivo.
+
+## Requisitos
+
+Instala las dependencias del proyecto:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+## Ayuda
+
+```bash
+python3 cli.py --help
+```
+
+## Calcular un salario
+
+Calcula el desglose para un bruto anual concreto. Por defecto usa el año 2026 y 12 pagas.
+
+```bash
+python3 cli.py salario 30000
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
+-----+-------------+---------------+------------+---------------+------------+-------------+-------------------
+2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+```
+
+Con año y número de pagas:
+
+```bash
+python3 cli.py salario 50000 --anio 2026 --pagas 14
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa  | SS trabajador | IRPF        | Neto anual  | Neto mensual (14p)
+-----+-------------+---------------+-------------+---------------+-------------+-------------+-------------------
+2026 | 50,000.00 € |   66,075.00 € | 16,075.00 € |    3,250.00 € | 11,204.50 € | 35,545.50 € |         2,538.96 €
+```
+
+## Tabla por rango salarial
+
+Genera una tabla pequeña entre dos brutos, con el salto indicado.
+
+```bash
+python3 cli.py tabla --anio 2026 --desde 20000 --hasta 40000 --paso 10000
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa  | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
+-----+-------------+---------------+-------------+---------------+------------+-------------+-------------------
+2026 | 20,000.00 € |   26,430.00 € |  6,430.00 € |    1,300.00 € | 1,773.32 € | 16,926.68 € |         1,410.56 €
+2026 | 30,000.00 € |   39,645.00 € |  9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+2026 | 40,000.00 € |   52,860.00 € | 12,860.00 € |    2,600.00 € | 7,745.00 € | 29,655.00 € |         2,471.25 €
+```
+
+## Comparar años
+
+Compara el mismo bruto nominal entre varios años.
+
+```bash
+python3 cli.py comparar 30000 --desde-anio 2024 --hasta-anio 2026
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
+-----+-------------+---------------+------------+---------------+------------+-------------+-------------------
+2024 | 30,000.00 € |   39,594.00 € | 9,594.00 € |    1,941.00 € | 4,928.70 € | 23,130.30 € |         1,927.52 €
+2025 | 30,000.00 € |   39,621.00 € | 9,621.00 € |    1,944.00 € | 4,927.80 € | 23,128.20 € |         1,927.35 €
+2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+```
+
+## Ejecutar como script
+
+`cli.py` puede ejecutarse directamente si tiene permisos de ejecución:
+
+```bash
+./cli.py salario 30000 --anio 2026
+```
+
+La salida es equivalente a `python3 cli.py salario 30000 --anio 2026`.
+
+## Nota
+
+El CLI reutiliza las funciones de `Calculo_Salario_IRPF.py`, pero evita ejecutar la sección final que genera `Auditoria_Integral_Nominas_e_Inflacion_2012_2026.xlsx`.

--- a/CLI.md
+++ b/CLI.md
@@ -82,6 +82,23 @@ Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | 
 2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
 ```
 
+## Comparar con IPC
+
+Compara un salario actual con el salario equivalente de un año anterior manteniendo la misma capacidad económica real. Por defecto compara contra 2019 y usa 2026 como año actual.
+
+```bash
+python3 cli.py ipc 30000 --anio-base 2019 --anio-actual 2026
+```
+
+Salida:
+
+```text
+Concepto    | Año  | Bruto anual | IPC acumulado | IRPF       | Neto anual  | Neto en euros 2026 | Dif. anual vs actual | Dif. mensual (12p)
+------------+------+-------------+---------------+------------+-------------+--------------------+----------------------+-------------------
+2019 equiv. | 2019 | 23,843.46 € |       1.2582x | 3,209.82 € | 19,119.58 € |        24,056.38 € |             932.38 € |            77.70 €
+2026 actual | 2026 | 30,000.00 € |       1.0000x | 4,926.00 € | 23,124.00 € |        23,124.00 € |               0.00 € |             0.00 €
+```
+
 ## Tipo marginal efectivo
 
 Muestra cuánto sube el neto anual por cada subida de bruto dentro de un rango. Es útil para ver zonas donde una subida salarial se convierte en poco neto disponible.

--- a/CLI.md
+++ b/CLI.md
@@ -1,107 +1,42 @@
 # CLI de consulta rápida
 
-Este fichero documenta `cli.py`, una capa ligera para consultar cálculos de salario sin generar el Excel masivo.
+`cli.py` permite consultar el motor fiscal sin generar el Excel masivo. El caso principal es comparar un salario actual con su equivalente real en 2019, ajustando por IPC.
 
-## Requisitos
+## Uso principal: 2019 vs 2026
 
-Instala las dependencias del proyecto:
-
-```bash
-python3 -m pip install -r requirements.txt
-```
-
-## Ayuda
+Por defecto, `ipc` compara un salario de 2026 contra su equivalente de 2019 con la misma capacidad económica real.
 
 ```bash
-python3 cli.py --help
-```
-
-## Calcular un salario
-
-Calcula el desglose para un bruto anual concreto. Por defecto usa el año 2026 y 12 pagas.
-
-```bash
-python3 cli.py salario 30000
+python3 cli.py ipc 30000
 ```
 
 Salida:
 
 ```text
-Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
------+-------------+---------------+------------+---------------+------------+-------------+-------------------
-2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+Concepto    | Año  | Bruto nominal | Bruto 2026  | IPC     | IRPF 2026  | Tipo IRPF | Dif. tipo | Neto 2026   | Dif. IRPF | Dif. neto/mes (12p)
+------------+------+---------------+-------------+---------+------------+-----------+-----------+-------------+-----------+--------------------
+2019 equiv. | 2019 |   23,843.46 € | 30,000.00 € | 1.2582x | 4,038.62 € |   13.46 % | 0.00 p.p. | 24,056.38 € |    0.00 € |              0.00 €
+2026 actual | 2026 |   30,000.00 € | 30,000.00 € | 1.0000x | 4,926.00 € |   16.42 % | 2.96 p.p. | 23,124.00 € |  887.38 € |            -77.70 €
 ```
 
-Con año y número de pagas:
+Cómo leerlo:
 
-```bash
-python3 cli.py salario 50000 --anio 2026 --pagas 14
-```
+- `2019 equiv.`: salario nominal de 2019 que equivale a `30.000 €` de 2026 tras aplicar IPC.
+- `IRPF 2026`: IRPF expresado en euros comparables de 2026.
+- `Tipo IRPF`: IRPF dividido entre el bruto equivalente de 2026.
+- `Dif. tipo`: aumento del tipo efectivo frente al caso equivalente de 2019.
+- `Dif. IRPF`: cuánto más IRPF se paga frente al caso equivalente de 2019.
+- `Dif. neto/mes`: pérdida o ganancia mensual neta frente al caso equivalente de 2019.
 
-Salida:
-
-```text
-Año  | Bruto anual | Coste empresa | SS empresa  | SS trabajador | IRPF        | Neto anual  | Neto mensual (14p)
------+-------------+---------------+-------------+---------------+-------------+-------------+-------------------
-2026 | 50,000.00 € |   66,075.00 € | 16,075.00 € |    3,250.00 € | 11,204.50 € | 35,545.50 € |         2,538.96 €
-```
-
-## Tabla por rango salarial
-
-Genera una tabla pequeña entre dos brutos, con el salto indicado.
-
-```bash
-python3 cli.py tabla --anio 2026 --desde 20000 --hasta 40000 --paso 10000
-```
-
-Salida:
-
-```text
-Año  | Bruto anual | Coste empresa | SS empresa  | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
------+-------------+---------------+-------------+---------------+------------+-------------+-------------------
-2026 | 20,000.00 € |   26,430.00 € |  6,430.00 € |    1,300.00 € | 1,773.32 € | 16,926.68 € |         1,410.56 €
-2026 | 30,000.00 € |   39,645.00 € |  9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
-2026 | 40,000.00 € |   52,860.00 € | 12,860.00 € |    2,600.00 € | 7,745.00 € | 29,655.00 € |         2,471.25 €
-```
-
-## Comparar años
-
-Compara el mismo bruto nominal entre varios años.
-
-```bash
-python3 cli.py comparar 30000 --desde-anio 2024 --hasta-anio 2026
-```
-
-Salida:
-
-```text
-Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
------+-------------+---------------+------------+---------------+------------+-------------+-------------------
-2024 | 30,000.00 € |   39,594.00 € | 9,594.00 € |    1,941.00 € | 4,928.70 € | 23,130.30 € |         1,927.52 €
-2025 | 30,000.00 € |   39,621.00 € | 9,621.00 € |    1,944.00 € | 4,927.80 € | 23,128.20 € |         1,927.35 €
-2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
-```
-
-## Comparar con IPC
-
-Compara un salario actual con el salario equivalente de un año anterior manteniendo la misma capacidad económica real. Por defecto compara contra 2019 y usa 2026 como año actual.
+Para cambiar los años:
 
 ```bash
 python3 cli.py ipc 30000 --anio-base 2019 --anio-actual 2026
 ```
 
-Salida:
+## Rentas bajas: tipo marginal efectivo
 
-```text
-Concepto    | Año  | Bruto anual | IPC acumulado | IRPF       | Neto anual  | Neto en euros 2026 | Dif. anual vs actual | Dif. mensual (12p)
-------------+------+-------------+---------------+------------+-------------+--------------------+----------------------+-------------------
-2019 equiv. | 2019 | 23,843.46 € |       1.2582x | 3,209.82 € | 19,119.58 € |        24,056.38 € |             932.38 € |            77.70 €
-2026 actual | 2026 | 30,000.00 € |       1.0000x | 4,926.00 € | 23,124.00 € |        23,124.00 € |               0.00 € |             0.00 €
-```
-
-## Tipo marginal efectivo
-
-Muestra cuánto sube el neto anual por cada subida de bruto dentro de un rango. Es útil para ver zonas donde una subida salarial se convierte en poco neto disponible.
+`marginal` muestra cuánto neto queda de cada subida bruta dentro de un rango. Es útil para ver zonas donde una subida salarial se convierte en poco neto disponible.
 
 ```bash
 python3 cli.py marginal --anio 2026 --desde 16500 --hasta 18500 --paso 500
@@ -119,15 +54,81 @@ Año  | Bruto anual | Neto anual  | Subida bruta | Subida neta | Tipo marginal e
 2026 | 18,500.00 € | 16,329.42 € |     500.00 € |    123.23 € |                75.35 %
 ```
 
-## Ejecutar como script
+## Otros comandos
 
-`cli.py` puede ejecutarse directamente si tiene permisos de ejecución:
+Calcular un salario concreto:
 
 ```bash
-./cli.py salario 30000 --anio 2026
+python3 cli.py salario 30000
 ```
 
-La salida es equivalente a `python3 cli.py salario 30000 --anio 2026`.
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
+-----+-------------+---------------+------------+---------------+------------+-------------+-------------------
+2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+```
+
+Generar una tabla pequeña por rango salarial:
+
+```bash
+python3 cli.py tabla --anio 2026 --desde 20000 --hasta 40000 --paso 10000
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa  | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
+-----+-------------+---------------+-------------+---------------+------------+-------------+-------------------
+2026 | 20,000.00 € |   26,430.00 € |  6,430.00 € |    1,300.00 € | 1,773.32 € | 16,926.68 € |         1,410.56 €
+2026 | 30,000.00 € |   39,645.00 € |  9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+2026 | 40,000.00 € |   52,860.00 € | 12,860.00 € |    2,600.00 € | 7,745.00 € | 29,655.00 € |         2,471.25 €
+```
+
+Comparar el mismo bruto nominal entre años:
+
+```bash
+python3 cli.py comparar 30000 --desde-anio 2024 --hasta-anio 2026
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | Neto anual  | Neto mensual (12p)
+-----+-------------+---------------+------------+---------------+------------+-------------+-------------------
+2024 | 30,000.00 € |   39,594.00 € | 9,594.00 € |    1,941.00 € | 4,928.70 € | 23,130.30 € |         1,927.52 €
+2025 | 30,000.00 € |   39,621.00 € | 9,621.00 € |    1,944.00 € | 4,927.80 € | 23,128.20 € |         1,927.35 €
+2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
+```
+
+`comparar` no ajusta por inflación. Para la comparación de salario real 2019 vs 2026, usa `ipc`.
+
+## Instalación y ayuda
+
+Instala las dependencias del proyecto:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+Ver comandos disponibles:
+
+```bash
+python3 cli.py --help
+```
+
+Salida resumida:
+
+```text
+usage: cli.py [-h] {ipc,marginal,salario,tabla,comparar} ...
+```
+
+`cli.py` también puede ejecutarse directamente si tiene permisos de ejecución:
+
+```bash
+./cli.py ipc 30000
+```
 
 ## Nota
 

--- a/CLI.md
+++ b/CLI.md
@@ -82,6 +82,26 @@ Año  | Bruto anual | Coste empresa | SS empresa | SS trabajador | IRPF       | 
 2026 | 30,000.00 € |   39,645.00 € | 9,645.00 € |    1,950.00 € | 4,926.00 € | 23,124.00 € |         1,927.00 €
 ```
 
+## Tipo marginal efectivo
+
+Muestra cuánto sube el neto anual por cada subida de bruto dentro de un rango. Es útil para ver zonas donde una subida salarial se convierte en poco neto disponible.
+
+```bash
+python3 cli.py marginal --anio 2026 --desde 16500 --hasta 18500 --paso 500
+```
+
+Salida:
+
+```text
+Año  | Bruto anual | Neto anual  | Subida bruta | Subida neta | Tipo marginal efectivo
+-----+-------------+-------------+--------------+-------------+-----------------------
+2026 | 16,500.00 € | 15,427.50 € |       0.00 € |      0.00 € |                 0.00 %
+2026 | 17,000.00 € | 15,895.00 € |     500.00 € |    467.50 € |                 6.50 %
+2026 | 17,500.00 € | 16,082.95 € |     500.00 € |    187.95 € |                62.41 %
+2026 | 18,000.00 € | 16,206.18 € |     500.00 € |    123.23 € |                75.35 %
+2026 | 18,500.00 € | 16,329.42 € |     500.00 € |    123.23 € |                75.35 %
+```
+
 ## Ejecutar como script
 
 `cli.py` puede ejecutarse directamente si tiene permisos de ejecución:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Bash
 python main.py
 (Nota: La generación del archivo Excel tomará unos minutos debido al enorme volumen de datos procesados. ¡Ten paciencia mientras se escribe el documento!)
 
+Consulta rápida por CLI: si solo quieres calcular salarios puntuales, tablas pequeñas o comparativas entre años sin generar el Excel masivo, revisa [CLI.md](CLI.md).
+
 📊 Entendiendo el Output (Excel Generado)
 El script genera un archivo llamado Auditoria_Integral_Nominas_e_Inflacion_2012_2026.xlsx con la siguiente estructura de pestañas:
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""CLI ligero para consultar el motor fiscal sin generar el Excel masivo."""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+SCRIPT_ORIGINAL = Path(__file__).with_name("Calculo_Salario_IRPF.py")
+MARCADOR_EJECUCION = "# 6. EJECUCIÓN MAESTRA Y GENERACIÓN DEL EXCEL COMPLETO"
+
+
+def cargar_motor():
+    """Carga funciones y datos del script original evitando su ejecución final."""
+    codigo = SCRIPT_ORIGINAL.read_text(encoding="utf-8")
+    codigo_motor = codigo.split(MARCADOR_EJECUCION, maxsplit=1)[0]
+    namespace = {}
+    exec(codigo_motor, namespace)
+    return namespace
+
+
+MOTOR = cargar_motor()
+
+
+def formatear_euros(valor):
+    return f"{valor:,.2f} €"
+
+
+def calcular_nomina_resumen(bruto, anio, pagas):
+    parametros = MOTOR["obtener_parametros"](anio)
+    coste, ss_empresa, ss_trabajador, irpf, neto = MOTOR["calcular_nomina_agregada"](
+        bruto, anio, parametros
+    )
+    return {
+        "Año": anio,
+        "Bruto anual": bruto,
+        "Coste empresa": coste,
+        "SS empresa": ss_empresa,
+        "SS trabajador": ss_trabajador,
+        "IRPF": irpf,
+        "Neto anual": neto,
+        f"Neto mensual ({pagas}p)": neto / pagas,
+    }
+
+
+def imprimir_tabla(filas):
+    if not filas:
+        print("No hay filas para mostrar.")
+        return
+
+    columnas = list(filas[0].keys())
+    filas_texto = []
+    for fila in filas:
+        valores = []
+        for columna in columnas:
+            valor = fila[columna]
+            valores.append(str(valor) if columna == "Año" else formatear_euros(valor))
+        filas_texto.append(valores)
+
+    anchos = [
+        max(len(str(columna)), *(len(fila[i]) for fila in filas_texto))
+        for i, columna in enumerate(columnas)
+    ]
+    cabecera = " | ".join(str(columna).ljust(anchos[i]) for i, columna in enumerate(columnas))
+    separador = "-+-".join("-" * ancho for ancho in anchos)
+
+    print(cabecera)
+    print(separador)
+    for fila in filas_texto:
+        print(" | ".join(valor.rjust(anchos[i]) for i, valor in enumerate(fila)))
+
+
+def cmd_salario(args):
+    imprimir_tabla([calcular_nomina_resumen(args.bruto, args.anio, args.pagas)])
+
+
+def cmd_tabla(args):
+    salarios = np.arange(args.desde, args.hasta + args.paso, args.paso)
+    filas = [
+        calcular_nomina_resumen(float(bruto), args.anio, args.pagas)
+        for bruto in salarios
+        if bruto <= args.hasta
+    ]
+    imprimir_tabla(filas)
+
+
+def cmd_comparar(args):
+    if args.desde_anio > args.hasta_anio:
+        raise SystemExit("--desde-anio no puede ser mayor que --hasta-anio")
+
+    filas = [
+        calcular_nomina_resumen(args.bruto, anio, args.pagas)
+        for anio in range(args.desde_anio, args.hasta_anio + 1)
+    ]
+    imprimir_tabla(filas)
+
+
+def crear_parser():
+    parser = argparse.ArgumentParser(
+        description="Consulta rápida de salario neto, IRPF y Seguridad Social en España (2012-2026)."
+    )
+    subparsers = parser.add_subparsers(dest="comando", required=True)
+
+    salario = subparsers.add_parser("salario", help="Calcula una nómina anual concreta.")
+    salario.add_argument("bruto", type=float, help="Salario bruto anual.")
+    salario.add_argument("--anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    salario.add_argument("--pagas", type=int, default=12, help="Número de pagas para el neto mensual.")
+    salario.set_defaults(func=cmd_salario)
+
+    tabla = subparsers.add_parser("tabla", help="Genera una tabla ligera por rango salarial.")
+    tabla.add_argument("--anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    tabla.add_argument("--desde", type=float, default=15000, help="Primer bruto anual.")
+    tabla.add_argument("--hasta", type=float, default=100000, help="Último bruto anual.")
+    tabla.add_argument("--paso", type=float, default=5000, help="Salto entre salarios.")
+    tabla.add_argument("--pagas", type=int, default=12, help="Número de pagas para el neto mensual.")
+    tabla.set_defaults(func=cmd_tabla)
+
+    comparar = subparsers.add_parser("comparar", help="Compara un mismo bruto nominal entre años.")
+    comparar.add_argument("bruto", type=float, help="Salario bruto anual.")
+    comparar.add_argument("--desde-anio", type=int, default=2012, choices=range(2012, 2027), metavar="YYYY")
+    comparar.add_argument("--hasta-anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    comparar.add_argument("--pagas", type=int, default=12, help="Número de pagas para el neto mensual.")
+    comparar.set_defaults(func=cmd_comparar)
+
+    return parser
+
+
+def main():
+    args = crear_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli.py
+++ b/cli.py
@@ -45,6 +45,39 @@ def calcular_nomina_resumen(bruto, anio, pagas):
     }
 
 
+def calcular_marginal(anio, desde, hasta, paso):
+    salarios = np.arange(desde, hasta + paso, paso)
+    filas = []
+    anterior = None
+
+    for bruto in salarios:
+        if bruto > hasta:
+            continue
+
+        resumen = calcular_nomina_resumen(float(bruto), anio, pagas=12)
+        fila = {
+            "Año": anio,
+            "Bruto anual": resumen["Bruto anual"],
+            "Neto anual": resumen["Neto anual"],
+            "Subida bruta": 0.0,
+            "Subida neta": 0.0,
+            "Tipo marginal efectivo": 0.0,
+        }
+
+        if anterior is not None:
+            subida_bruta = fila["Bruto anual"] - anterior["Bruto anual"]
+            subida_neta = fila["Neto anual"] - anterior["Neto anual"]
+            fila["Subida bruta"] = subida_bruta
+            fila["Subida neta"] = subida_neta
+            if subida_bruta:
+                fila["Tipo marginal efectivo"] = (1 - subida_neta / subida_bruta) * 100
+
+        filas.append(fila)
+        anterior = fila
+
+    return filas
+
+
 def imprimir_tabla(filas):
     if not filas:
         print("No hay filas para mostrar.")
@@ -56,7 +89,12 @@ def imprimir_tabla(filas):
         valores = []
         for columna in columnas:
             valor = fila[columna]
-            valores.append(str(valor) if columna == "Año" else formatear_euros(valor))
+            if columna == "Año":
+                valores.append(str(valor))
+            elif columna == "Tipo marginal efectivo":
+                valores.append(f"{valor:,.2f} %")
+            else:
+                valores.append(formatear_euros(valor))
         filas_texto.append(valores)
 
     anchos = [
@@ -97,6 +135,15 @@ def cmd_comparar(args):
     imprimir_tabla(filas)
 
 
+def cmd_marginal(args):
+    if args.desde > args.hasta:
+        raise SystemExit("--desde no puede ser mayor que --hasta")
+    if args.paso <= 0:
+        raise SystemExit("--paso debe ser mayor que 0")
+
+    imprimir_tabla(calcular_marginal(args.anio, args.desde, args.hasta, args.paso))
+
+
 def crear_parser():
     parser = argparse.ArgumentParser(
         description="Consulta rápida de salario neto, IRPF y Seguridad Social en España (2012-2026)."
@@ -123,6 +170,16 @@ def crear_parser():
     comparar.add_argument("--hasta-anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
     comparar.add_argument("--pagas", type=int, default=12, help="Número de pagas para el neto mensual.")
     comparar.set_defaults(func=cmd_comparar)
+
+    marginal = subparsers.add_parser(
+        "marginal",
+        help="Muestra cuánto neto queda de cada subida bruta dentro de un rango.",
+    )
+    marginal.add_argument("--anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    marginal.add_argument("--desde", type=float, default=15000, help="Primer bruto anual.")
+    marginal.add_argument("--hasta", type=float, default=25000, help="Último bruto anual.")
+    marginal.add_argument("--paso", type=float, default=500, help="Salto entre salarios.")
+    marginal.set_defaults(func=cmd_marginal)
 
     return parser
 

--- a/cli.py
+++ b/cli.py
@@ -78,6 +78,41 @@ def calcular_marginal(anio, desde, hasta, paso):
     return filas
 
 
+def calcular_comparativa_ipc(bruto_actual, anio_base, anio_actual, pagas):
+    inflacion = MOTOR["obtener_inflacion_acumulada"](anio_base, anio_actual)
+    bruto_base = bruto_actual / inflacion
+
+    base = calcular_nomina_resumen(bruto_base, anio_base, pagas)
+    actual = calcular_nomina_resumen(bruto_actual, anio_actual, pagas)
+    neto_base_actualizado = base["Neto anual"] * inflacion
+    diferencia_anual = neto_base_actualizado - actual["Neto anual"]
+
+    return [
+        {
+            "Concepto": f"{anio_base} equiv.",
+            "Año": anio_base,
+            "Bruto anual": bruto_base,
+            "IPC acumulado": inflacion,
+            "IRPF": base["IRPF"],
+            "Neto anual": base["Neto anual"],
+            f"Neto en euros {anio_actual}": neto_base_actualizado,
+            "Dif. anual vs actual": diferencia_anual,
+            f"Dif. mensual ({pagas}p)": diferencia_anual / pagas,
+        },
+        {
+            "Concepto": f"{anio_actual} actual",
+            "Año": anio_actual,
+            "Bruto anual": bruto_actual,
+            "IPC acumulado": 1.0,
+            "IRPF": actual["IRPF"],
+            "Neto anual": actual["Neto anual"],
+            f"Neto en euros {anio_actual}": actual["Neto anual"],
+            "Dif. anual vs actual": 0.0,
+            f"Dif. mensual ({pagas}p)": 0.0,
+        },
+    ]
+
+
 def imprimir_tabla(filas):
     if not filas:
         print("No hay filas para mostrar.")
@@ -91,8 +126,12 @@ def imprimir_tabla(filas):
             valor = fila[columna]
             if columna == "Año":
                 valores.append(str(valor))
+            elif columna in {"Concepto"}:
+                valores.append(str(valor))
             elif columna == "Tipo marginal efectivo":
                 valores.append(f"{valor:,.2f} %")
+            elif columna == "IPC acumulado":
+                valores.append(f"{valor:,.4f}x")
             else:
                 valores.append(formatear_euros(valor))
         filas_texto.append(valores)
@@ -144,6 +183,20 @@ def cmd_marginal(args):
     imprimir_tabla(calcular_marginal(args.anio, args.desde, args.hasta, args.paso))
 
 
+def cmd_ipc(args):
+    if args.anio_base >= args.anio_actual:
+        raise SystemExit("--anio-base debe ser anterior a --anio-actual")
+
+    imprimir_tabla(
+        calcular_comparativa_ipc(
+            args.bruto_actual,
+            args.anio_base,
+            args.anio_actual,
+            args.pagas,
+        )
+    )
+
+
 def crear_parser():
     parser = argparse.ArgumentParser(
         description="Consulta rápida de salario neto, IRPF y Seguridad Social en España (2012-2026)."
@@ -180,6 +233,16 @@ def crear_parser():
     marginal.add_argument("--hasta", type=float, default=25000, help="Último bruto anual.")
     marginal.add_argument("--paso", type=float, default=500, help="Salto entre salarios.")
     marginal.set_defaults(func=cmd_marginal)
+
+    ipc = subparsers.add_parser(
+        "ipc",
+        help="Compara un salario actual con su equivalente real en un año anterior.",
+    )
+    ipc.add_argument("bruto_actual", type=float, help="Salario bruto anual del año actual.")
+    ipc.add_argument("--anio-base", type=int, default=2019, choices=range(2012, 2027), metavar="YYYY")
+    ipc.add_argument("--anio-actual", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    ipc.add_argument("--pagas", type=int, default=12, help="Número de pagas para la diferencia mensual.")
+    ipc.set_defaults(func=cmd_ipc)
 
     return parser
 

--- a/cli.py
+++ b/cli.py
@@ -84,31 +84,39 @@ def calcular_comparativa_ipc(bruto_actual, anio_base, anio_actual, pagas):
 
     base = calcular_nomina_resumen(bruto_base, anio_base, pagas)
     actual = calcular_nomina_resumen(bruto_actual, anio_actual, pagas)
+    irpf_base_actualizado = base["IRPF"] * inflacion
     neto_base_actualizado = base["Neto anual"] * inflacion
-    diferencia_anual = neto_base_actualizado - actual["Neto anual"]
+    tipo_base = irpf_base_actualizado / bruto_actual * 100 if bruto_actual else 0.0
+    tipo_actual = actual["IRPF"] / bruto_actual * 100 if bruto_actual else 0.0
+    diferencia_irpf = actual["IRPF"] - irpf_base_actualizado
+    diferencia_neto = actual["Neto anual"] - neto_base_actualizado
 
     return [
         {
             "Concepto": f"{anio_base} equiv.",
             "Año": anio_base,
-            "Bruto anual": bruto_base,
-            "IPC acumulado": inflacion,
-            "IRPF": base["IRPF"],
-            "Neto anual": base["Neto anual"],
-            f"Neto en euros {anio_actual}": neto_base_actualizado,
-            "Dif. anual vs actual": diferencia_anual,
-            f"Dif. mensual ({pagas}p)": diferencia_anual / pagas,
+            "Bruto nominal": bruto_base,
+            f"Bruto {anio_actual}": bruto_actual,
+            "IPC": inflacion,
+            f"IRPF {anio_actual}": irpf_base_actualizado,
+            "Tipo IRPF": tipo_base,
+            "Dif. tipo": 0.0,
+            f"Neto {anio_actual}": neto_base_actualizado,
+            "Dif. IRPF": 0.0,
+            f"Dif. neto/mes ({pagas}p)": 0.0,
         },
         {
             "Concepto": f"{anio_actual} actual",
             "Año": anio_actual,
-            "Bruto anual": bruto_actual,
-            "IPC acumulado": 1.0,
-            "IRPF": actual["IRPF"],
-            "Neto anual": actual["Neto anual"],
-            f"Neto en euros {anio_actual}": actual["Neto anual"],
-            "Dif. anual vs actual": 0.0,
-            f"Dif. mensual ({pagas}p)": 0.0,
+            "Bruto nominal": bruto_actual,
+            f"Bruto {anio_actual}": bruto_actual,
+            "IPC": 1.0,
+            f"IRPF {anio_actual}": actual["IRPF"],
+            "Tipo IRPF": tipo_actual,
+            "Dif. tipo": tipo_actual - tipo_base,
+            f"Neto {anio_actual}": actual["Neto anual"],
+            "Dif. IRPF": diferencia_irpf,
+            f"Dif. neto/mes ({pagas}p)": diferencia_neto / pagas,
         },
     ]
 
@@ -128,9 +136,11 @@ def imprimir_tabla(filas):
                 valores.append(str(valor))
             elif columna in {"Concepto"}:
                 valores.append(str(valor))
-            elif columna == "Tipo marginal efectivo":
+            elif columna in {"Tipo marginal efectivo", "Tipo IRPF"}:
                 valores.append(f"{valor:,.2f} %")
-            elif columna == "IPC acumulado":
+            elif columna == "Dif. tipo":
+                valores.append(f"{valor:,.2f} p.p.")
+            elif columna == "IPC":
                 valores.append(f"{valor:,.4f}x")
             else:
                 valores.append(formatear_euros(valor))
@@ -203,6 +213,26 @@ def crear_parser():
     )
     subparsers = parser.add_subparsers(dest="comando", required=True)
 
+    ipc = subparsers.add_parser(
+        "ipc",
+        help="Compara un salario actual con su equivalente real en un año anterior.",
+    )
+    ipc.add_argument("bruto_actual", type=float, help="Salario bruto anual del año actual.")
+    ipc.add_argument("--anio-base", type=int, default=2019, choices=range(2012, 2027), metavar="YYYY")
+    ipc.add_argument("--anio-actual", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    ipc.add_argument("--pagas", type=int, default=12, help="Número de pagas para la diferencia mensual.")
+    ipc.set_defaults(func=cmd_ipc)
+
+    marginal = subparsers.add_parser(
+        "marginal",
+        help="Muestra cuánto neto queda de cada subida bruta dentro de un rango.",
+    )
+    marginal.add_argument("--anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
+    marginal.add_argument("--desde", type=float, default=15000, help="Primer bruto anual.")
+    marginal.add_argument("--hasta", type=float, default=25000, help="Último bruto anual.")
+    marginal.add_argument("--paso", type=float, default=500, help="Salto entre salarios.")
+    marginal.set_defaults(func=cmd_marginal)
+
     salario = subparsers.add_parser("salario", help="Calcula una nómina anual concreta.")
     salario.add_argument("bruto", type=float, help="Salario bruto anual.")
     salario.add_argument("--anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
@@ -223,26 +253,6 @@ def crear_parser():
     comparar.add_argument("--hasta-anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
     comparar.add_argument("--pagas", type=int, default=12, help="Número de pagas para el neto mensual.")
     comparar.set_defaults(func=cmd_comparar)
-
-    marginal = subparsers.add_parser(
-        "marginal",
-        help="Muestra cuánto neto queda de cada subida bruta dentro de un rango.",
-    )
-    marginal.add_argument("--anio", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
-    marginal.add_argument("--desde", type=float, default=15000, help="Primer bruto anual.")
-    marginal.add_argument("--hasta", type=float, default=25000, help="Último bruto anual.")
-    marginal.add_argument("--paso", type=float, default=500, help="Salto entre salarios.")
-    marginal.set_defaults(func=cmd_marginal)
-
-    ipc = subparsers.add_parser(
-        "ipc",
-        help="Compara un salario actual con su equivalente real en un año anterior.",
-    )
-    ipc.add_argument("bruto_actual", type=float, help="Salario bruto anual del año actual.")
-    ipc.add_argument("--anio-base", type=int, default=2019, choices=range(2012, 2027), metavar="YYYY")
-    ipc.add_argument("--anio-actual", type=int, default=2026, choices=range(2012, 2027), metavar="YYYY")
-    ipc.add_argument("--pagas", type=int, default=12, help="Número de pagas para la diferencia mensual.")
-    ipc.set_defaults(func=cmd_ipc)
 
     return parser
 


### PR DESCRIPTION
## Qué cambia

Añade un CLI independiente (`cli.py`) para consultar cálculos de salario sin generar el Excel masivo. También añade `CLI.md` con instrucciones de uso y ejemplos con salidas reales.

## Por qué

El script actual genera un Excel muy grande con todas las auditorías anuales. Este PR ofrece una forma rápida de consultar casos puntuales, rangos pequeños y comparativas entre años desde terminal.

## Alcance

- No modifica `Calculo_Salario_IRPF.py`.
- Reutiliza el motor existente leyendo solo la parte de funciones del script original.
- Evita ejecutar la sección final que crea `Auditoria_Integral_Nominas_e_Inflacion_2012_2026.xlsx`.
- Añade comandos `salario`, `tabla` y `comparar`.

## Cómo probarlo

```bash
python3 cli.py --help
python3 cli.py salario 30000 --anio 2026
python3 cli.py tabla --anio 2026 --desde 20000 --hasta 40000 --paso 10000
python3 cli.py comparar 30000 --desde-anio 2024 --hasta-anio 2026
```

## Validación realizada

Ejecutados correctamente:

```bash
python3 cli.py --help
python3 cli.py salario 30000 --anio 2026
python3 cli.py tabla --anio 2026 --desde 20000 --hasta 40000 --paso 10000
```